### PR TITLE
Fixed newer ESLint (8+) compatibility

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,5 @@
 {
-  "presets": ["es2015"]
+  "presets": [
+    "@babel/preset-env"
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules
 
 lib
 .idea
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This plugin treats Jinja template expressions and statements as valid Javascript
 
 As a note, it is possible that this best effort conversion yeilds false negatives or positives because it is impossible to know the right way to insert placeholders.
 
+Also - some complex inline expressions might break and you might have to expand them.
+
 ### Example
 
 Plugin will convert (internally) this code:
@@ -28,7 +30,7 @@ Plugin will convert (internally) this code:
     var d = {% if something %} 'this is something' {% else %} null {% endif %};
 
     {# any other statements become comments #}
-    
+
     {% for i in [1, 2, 3] %}
       console.log(a, b, c, d);
     {% endfor %}
@@ -39,10 +41,9 @@ into this:
  (function() {
     'use strict';
 
-    /* plain jinja variables are converted into strings
-      (preferred quotes are getting from .eslintrc file) */
-
-    var a = 'this is' + '  some_variable  ';
+    /* plain jinja variables are converted into zeroed out regex patterns
+      to avoid having to guess preferred quotes */
+    var a = 'this is' + /00000000000/;
 
     /* if it is already in string, it is wrapped with spaces */
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@eladavron/eslint-plugin-jinja",
-  "version": "0.3.0",
-  "description": "This plugin treats Jinja template expressions as Javascript literals and ignores template statements and comments. It is a fork and update of the original eslint-plugin-jinja package by alexkuz.",
+  "version": "0.3.1",
+  "description": "This plugin treats Jinja template expressions as Javascript literals and ignores template statements and comments.",
   "main": "lib/index.js",
   "scripts": {
     "test": "npm test",
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/eladavron/eslint-plugin-jinja.git"
+    "url": "git+https://github.com/alexkuz/eslint-plugin-jinja.git"
   },
   "keywords": [
     "eslint",
@@ -22,17 +22,15 @@
     "jinja2",
     "template"
   ],
-  "author": "Elad Avron <eladavron@gmail.com>",
-  "maintainers": [{
-    "email": "eladavron@gmail.com",
-    "name": "Elad Avron",
-    "url": "https://github.com/eladavron/eslint-plugin-jinja/"
-  }],
+  "author": "Alexander <alexkuz@gmail.com> (http://kuzya.org/)",
+  "contributors": [
+    "Elad Avron <eladavron@gmail.com>"
+  ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/eladavron/eslint-plugin-jinja/issues"
+    "url": "https://github.com/alexkuz/eslint-plugin-jinja/issues"
   },
-  "homepage": "https://github.com/eladavron/eslint-plugin-jinja#readme",
+  "homepage": "https://github.com/alexkuz/eslint-plugin-jinja#readme",
   "devDependencies": {
     "@babel/cli": "^7.16.7",
     "@babel/core": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,19 @@
 {
-  "name": "eslint-plugin-jinja",
-  "version": "0.1.0",
-  "description": "This plugin treats Jinja template expressions as Javascript literals and ignores template statements and comments",
+  "name": "@eladavron/eslint-plugin-jinja",
+  "version": "0.3.0",
+  "description": "This plugin treats Jinja template expressions as Javascript literals and ignores template statements and comments. It is a fork and update of the original eslint-plugin-jinja package by alexkuz.",
   "main": "lib/index.js",
   "scripts": {
     "test": "npm test",
     "build": "babel src --out-dir lib",
+    "watch": "watch 'npm run build' ./src",
     "version": "npm run build && git add -A .",
     "postversion": "git push",
     "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alexkuz/eslint-plugin-jinja.git"
+    "url": "git+https://github.com/eladavron/eslint-plugin-jinja.git"
   },
   "keywords": [
     "eslint",
@@ -21,20 +22,28 @@
     "jinja2",
     "template"
   ],
-  "author": "Alexander <alexkuz@gmail.com> (http://kuzya.org/)",
+  "author": "Elad Avron <eladavron@gmail.com>",
+  "maintainers": [{
+    "email": "eladavron@gmail.com",
+    "name": "Elad Avron",
+    "url": "https://github.com/eladavron/eslint-plugin-jinja/"
+  }],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/alexkuz/eslint-plugin-jinja/issues"
+    "url": "https://github.com/eladavron/eslint-plugin-jinja/issues"
   },
-  "homepage": "https://github.com/alexkuz/eslint-plugin-jinja#readme",
+  "homepage": "https://github.com/eladavron/eslint-plugin-jinja#readme",
   "devDependencies": {
-    "babel-cli": "^6.3.15",
-    "babel-core": "^6.3.15",
-    "babel-eslint": "^5.0.0",
-    "babel-preset-es2015": "^6.5.0",
-    "eslint": "^2.2.0"
+    "@babel/cli": "^7.16.7",
+    "@babel/core": "^7.16.7",
+    "@babel/eslint-parser": "^7.16.5",
+    "@babel/plugin-transform-runtime": "^7.16.7",
+    "@babel/preset-env": "^7.16.7",
+    "eslint": "^8.6.0",
+    "glob": "^7.2.0",
+    "watch": "^1.0.2"
   },
   "peerDependencies": {
-    "eslint": "^0.23.0 || ^1.0.0 || ^2.0.0"
+    "eslint": "^8.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,38 +1,39 @@
 'use strict';
-import { CLIEngine } from 'eslint';
-import path from 'path';
 
 const processHTML = {
-  preprocess(text, filename) {
-    const config = new CLIEngine({ useEslintrc: true }).getConfigForFile(path.resolve(filename));
-    const quote = config.rules.quotes[1] === 'double' ? '"' : '\'';
-    text = text;
-    const processed = text
-    // replace jinja comments with js comments
-      .replace(/\{#([\s\S]*?)#\}/g, (str, val) => `/*${val}*/`)
-    // treat if-else statement as ( ... , ... )
-      .replace(/\{%(-?\s*if.*?)%\}/g, (str, val) => `(/*${val.substr(1)}*/`)
-      .replace(/\{%(-?\s*(else|elif).*?)%\}/g, (str, val) => `,/*${val.substr(1)}*/`)
-      .replace(/\{%(-?\s*endif\s*-?)%\}/g, (str, val) => `/*${val.substr(1)}*/)`)
-    // replace jinja statements with js comments
-      .replace(/\{%(.*?)%\}/g, (str, val) => `/*${val}*/`)
-    // replace jinja expression tags in strings with spaces
-      .replace(/\{[{%]([\s\S]*?)[}%]\}/g, str => str.replace(/['"]/g, ' '))
-      .replace(/(['"])(.*?)\1/g, str => str.replace(/(\{\{|\}\})/g, '  '))
-    // replace jinja expressions with strings
-      .replace(/\{\{(.*?)\}\}/g, (str, val) => `${quote} ${val} ${quote}`);
-    return [processed];
-  },
+    preprocess(text, _) {
+        text = text;
+        var processed = text
+            // replace jinja comments with js comments
+            .replace(/\{#([\s\S]*?)#\}/g, (str, val) => `/*${val}*/`)
 
-  postprocess(messages) {
-    return messages[0];
-  }
+            // treat if-else statement as ( ... , ... )
+            .replace(/\{%(-?\s*if.*?)%\}/g, (str, val) => `/*${val.substr(1)}*/`)
+            .replace(/\{%(-?\s*(else|elif).*?)%\}/g, (str, val) => `/*${val.substr(1)}*/`)
+            .replace(/\{%(-?\s*endif\s*-?)%\}/g, (str, val) => `/*${val.substr(1)}*/`)
+
+            // replace jinja statements with js comments
+            .replace(/\{%(.*?)%\}/g, (str, val) => `/*${val}*/`)
+
+            // replace jinja expression tags in strings with spaces
+            .replace(/\{[{%]([\s\S]*?)[}%]\}/g, str => str.replace(/['"]/g, ' '))
+            .replace(/(['"])(.*?)\1/g, str => str.replace(/(\{\{|\}\})/g, '  '))
+
+            // replace jinja expressions with a regex pattern - which is independent of quotes.
+            // It is padded to the length of the expression to avoid misaligning anything after it inline.
+            .replace(/\{\{(.*?)\}\}/g, str => "/" + ("/".padStart(str.length, 0)));
+        return [processed];
+    },
+
+    postprocess(messages) {
+        return messages[0];
+    }
 };
 
-export default {
-  processors: {
-    '.js': processHTML,
-    '.html': processHTML,
-    '.htm': processHTML
-  }
+module.exports = {
+    processors: {
+        '.js': processHTML,
+        '.html': processHTML,
+        '.htm': processHTML
+    }
 };


### PR DESCRIPTION
Since ESLint 8+ doesn't use `CLIEngine` anymore, and the alternative to it (`ESLint`) is async, I had to get creative with the quotes.  

Instead of trying to determine which quotes the user will be using and converting the Jinja expression into a string, I just convert it to a regex expression - which is independent of quote type.

I make it all 0s to avoid invalid regex expressions, and pad it to the length of the original expression to avoid misaligning anything that comes after it.